### PR TITLE
add accessors x, y, z to small_array

### DIFF
--- a/include/CL/sycl/detail/small_array.hpp
+++ b/include/CL/sycl/detail/small_array.hpp
@@ -95,8 +95,20 @@ struct small_array : std::array<BasicType, Dims>,
     // (*this)[0] is the first element of the underlying array
     std::copy_n(src, Dims, &(*this)[0]);
   }
-
-
+      
+  BasicType& x(){
+	  static_assert(Dims>=1, "can't access to small_array[0] if Dims<1");
+	  return (*this)[0];
+  }
+  BasicType& y(){
+	  static_assert(Dims>=2, "can't access to small_array[1] if Dims<2");
+	  return (*this)[1];
+  }
+  BasicType& z(){
+	  static_assert(Dims>=3, "can't access to small_array[2] if Dims<3");
+	  return (*this)[2];
+  }
+      
   /// A constructor from another small_array of the same size
   template <typename SourceBasicType,
             typename SourceFinalType,

--- a/include/CL/sycl/detail/small_array.hpp
+++ b/include/CL/sycl/detail/small_array.hpp
@@ -95,20 +95,32 @@ struct small_array : std::array<BasicType, Dims>,
     // (*this)[0] is the first element of the underlying array
     std::copy_n(src, Dims, &(*this)[0]);
   }
-      
+
+
+  /** An accessor to the first variable of a small array
+  */
   BasicType& x(){
-	  static_assert(Dims>=1, "can't access to small_array[0] if Dims<1");
-	  return (*this)[0];
+    static_assert(Dims >= 1, "can't access to small_array[0] if Dims < 1");
+    return (*this)[0];
   }
+
+
+  /** An accessor to the second variable of a small array
+  */
   BasicType& y(){
-	  static_assert(Dims>=2, "can't access to small_array[1] if Dims<2");
-	  return (*this)[1];
+    static_assert(Dims >= 2, "can't access to small_array[1] if Dims < 2");
+    return (*this)[1];
   }
+
+
+  /** An accessor to the third variable of a small array
+  */
   BasicType& z(){
-	  static_assert(Dims>=3, "can't access to small_array[2] if Dims<3");
-	  return (*this)[2];
+    static_assert(Dims >= 3, "can't access to small_array[2] if Dims < 3");
+    return (*this)[2];
   }
-      
+
+
   /// A constructor from another small_array of the same size
   template <typename SourceBasicType,
             typename SourceFinalType,

--- a/tests/vector/vecacc.cpp
+++ b/tests/vector/vecacc.cpp
@@ -1,0 +1,40 @@
+/* RUN: %{execute}%s
+
+   Test some vec<> behaviour
+*/
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <boost/test/minimal.hpp>
+
+using namespace cl::sycl;
+
+
+/// Return true if both contents are the same
+template <typename Vec>
+bool equal(const Vec &v, const Vec &verif) {
+  /* Do not use directly v == verif because we want to verify the
+     (implicit) constructor itself */
+  auto p = std::begin(verif);
+  for (auto e : v)
+    if (e != *p++)
+      return false;
+
+  return true;
+}
+
+
+
+
+int test_main(int argc, char *argv[]) {
+	vec<int, 3> v = {1, 2, 3};
+	BOOST_CHECK(v.x() == 1);
+	BOOST_CHECK(v.y() == 2);
+	BOOST_CHECK(v.z() == 3);
+	v.x() = 4;
+	v.y() = 5;
+	v.z() = 6;
+	BOOST_CHECK(v.x() == 4);
+	BOOST_CHECK(v.y() == 5);
+	BOOST_CHECK(v.z() == 6);
+  return 0;
+}

--- a/tests/vector/vecacc.cpp
+++ b/tests/vector/vecacc.cpp
@@ -8,23 +8,6 @@
 
 using namespace cl::sycl;
 
-
-/// Return true if both contents are the same
-template <typename Vec>
-bool equal(const Vec &v, const Vec &verif) {
-  /* Do not use directly v == verif because we want to verify the
-     (implicit) constructor itself */
-  auto p = std::begin(verif);
-  for (auto e : v)
-    if (e != *p++)
-      return false;
-
-  return true;
-}
-
-
-
-
 int test_main(int argc, char *argv[]) {
 	vec<int, 3> v = {1, 2, 3};
 	BOOST_CHECK(v.x() == 1);


### PR DESCRIPTION
accessors x and y are needed by the SyclParallelSTL
accessors x, y and z are necessary if we use vec to implement cl_float3